### PR TITLE
Remove endHttpSegment

### DIFF
--- a/src/Collectors/SegmentCollector.php
+++ b/src/Collectors/SegmentCollector.php
@@ -16,7 +16,7 @@ class SegmentCollector
     use Backtracer;
 
     /** @var array */
-    protected $segments;
+    protected $segments = [];
 
     public function tracer(): Trace
     {
@@ -131,18 +131,6 @@ class SegmentCollector
     public function endSegment(string $name): void
     {
         if ($this->hasAddedSegment($name)) {
-            $this->segments[$name]->end();
-
-            unset($this->segments[$name]);
-        }
-    }
-
-    public function endHttpSegment(string $name, ?int $responseCode = 200): void
-    {
-        if ($this->hasAddedSegment($name)) {
-            if ($this->segments[$name] instanceof HttpSegment) {
-                $this->segments[$name]->setResponseCode($responseCode);
-            }
             $this->segments[$name]->end();
 
             unset($this->segments[$name]);

--- a/src/Collectors/SegmentCollector.php
+++ b/src/Collectors/SegmentCollector.php
@@ -103,7 +103,7 @@ class SegmentCollector
         return $segment;
     }
 
-    public function addHttpSegment(string $url, ?array $config = []): Segment
+    public function addHttpSegment(string $url, ?array $config = []): HttpSegment
     {
         $name = $config['name'] ?? $url;
         $method = $config['method'] ?? 'GET';

--- a/src/Xray.php
+++ b/src/Xray.php
@@ -6,6 +6,7 @@ namespace Napp\Xray;
 
 use Illuminate\Http\Request;
 use Napp\Xray\Collectors\SegmentCollector;
+use Napp\Xray\Segments\HttpSegment;
 use Pkerrigan\Xray\Segment;
 use Pkerrigan\Xray\Trace;
 
@@ -59,7 +60,7 @@ class Xray
      * @param array|null $config
      * @return Segment
      */
-    public function addHttpSegment(string $url, ?array $config = []): Segment
+    public function addHttpSegment(string $url, ?array $config = []): HttpSegment
     {
         return $this->collector->addHttpSegment($url, $config);
     }

--- a/src/Xray.php
+++ b/src/Xray.php
@@ -74,18 +74,6 @@ class Xray
         $this->collector->endSegment($name);
     }
 
-    /**
-     * End HTTP segment by segment name
-     *
-     * @param string $name
-     * @param integer|null $responseCode = 200
-     * @return void
-     */
-    public function endHttpSegment(string $name, ?int $responseCode = 200): void
-    {
-        $this->collector->endHttpSegment($name, $responseCode);
-    }
-
     public function hasAddedSegment(string $name): bool
     {
         return $this->collector->hasAddedSegment($name);

--- a/tests/Collectors/SegmentCollectorTest.php
+++ b/tests/Collectors/SegmentCollectorTest.php
@@ -43,7 +43,7 @@ class SegmentCollectorTest extends TestCase
         $this->assertEquals('POST', $data['http']['request']['method']);
         $this->assertEquals('http://example.com', $data['http']['request']['url']);
 
-        $collector->endHttpSegment('example', 400);
+        $collector->endSegment('example');
 
         $this->assertNull($collector->getSegment('example'));
 
@@ -51,11 +51,17 @@ class SegmentCollectorTest extends TestCase
         $this->assertEquals(400, $data['http']['response']['status']);
     }
 
+    public function test_end_empty_segments_wont_throw_exception()
+    {
+        $collector = new SegmentCollector();
+        $collector->endSegment('some-segment');
+
+        $this->assertTrue(true);
+    }
+
     protected function createRequest(): MockObject
     {
-        $request = $this->getMockBuilder(Request::class)
-            ->setMethods(['ip', 'url', 'method', 'path'])
-            ->getMock();
+        $request = $this->getMockBuilder(Request::class)->getMock();
 
         $request->expects($this->any())->method('ip')->willReturn('some-ip');
         $request->expects($this->any())->method('url')->willReturn('some-url');

--- a/tests/Collectors/SegmentCollectorTest.php
+++ b/tests/Collectors/SegmentCollectorTest.php
@@ -37,11 +37,13 @@ class SegmentCollectorTest extends TestCase
     public function test_should_add_http_segment()
     {
         $collector = new SegmentCollector();
-        $collector->addHttpSegment('http://example.com', ['method' => 'POST', 'name' => 'example']);
+        $segment = $collector->addHttpSegment('http://example.com', ['method' => 'POST', 'name' => 'example']);
 
         $data = $collector->getSegment('example')->jsonSerialize();
         $this->assertEquals('POST', $data['http']['request']['method']);
         $this->assertEquals('http://example.com', $data['http']['request']['url']);
+
+        $segment->setResponseCode(400);
 
         $collector->endSegment('example');
 
@@ -55,6 +57,8 @@ class SegmentCollectorTest extends TestCase
     {
         $collector = new SegmentCollector();
         $collector->endSegment('some-segment');
+        $collector->hasAddedSegment('some-segment');
+        $collector->getSegment('some-segment');
 
         $this->assertTrue(true);
     }

--- a/tests/XRayTest.php
+++ b/tests/XRayTest.php
@@ -25,7 +25,6 @@ class XrayTest extends TestCase
         $collector->expects($this->once())->method('addCustomSegment')->with($segment, 'name');
         $collector->expects($this->once())->method('addHttpSegment')->with('url', []);
         $collector->expects($this->once())->method('getSegment')->with('name');
-        $collector->expects($this->once())->method('endSegment')->with('name');
         $collector->expects($this->once())->method('endHttpSegment')->with('name');
         $collector->expects($this->once())->method('hasAddedSegment')->with('name');
         $collector->expects($this->once())->method('endCurrentSegment');
@@ -38,7 +37,6 @@ class XrayTest extends TestCase
         $xray->addHttpSegment('url');
         $xray->getSegment('name');
         $xray->endSegment('name');
-        $xray->endHttpSegment('name');
         $xray->hasAddedSegment('name');
         $xray->endCurrentSegment();
     }

--- a/tests/XRayTest.php
+++ b/tests/XRayTest.php
@@ -25,7 +25,7 @@ class XrayTest extends TestCase
         $collector->expects($this->once())->method('addCustomSegment')->with($segment, 'name');
         $collector->expects($this->once())->method('addHttpSegment')->with('url', []);
         $collector->expects($this->once())->method('getSegment')->with('name');
-        $collector->expects($this->once())->method('endHttpSegment')->with('name');
+        $collector->expects($this->once())->method('endSegment')->with('name');
         $collector->expects($this->once())->method('hasAddedSegment')->with('name');
         $collector->expects($this->once())->method('endCurrentSegment');
 


### PR DESCRIPTION
- 把 `endHttpSegment` 移除，單純用 `endSegment` 即可。
- 即使尚未初始化（`initHttpTracer`）使用 `endSegment` `getSegment`  不應有錯。