### PR TITLE
Check counting when binding query

### DIFF
--- a/src/Collectors/DatabaseQueryCollector.php
+++ b/src/Collectors/DatabaseQueryCollector.php
@@ -23,7 +23,7 @@ class DatabaseQueryCollector extends EventsCollector
         $this->bindingsEnabled = config('xray.db_bindings');
     }
 
-    protected function handleQueryReport(string $sql, array $bindings, float $time, Connection $connection): void
+    public function handleQueryReport(string $sql, array $bindings, float $time, Connection $connection): void
     {
         if ($this->bindingsEnabled) {
             $sql = $this->parseBindings($sql, $bindings, $connection);
@@ -44,6 +44,10 @@ class DatabaseQueryCollector extends EventsCollector
 
     private function parseBindings(string $sql, array $bindings, Connection $connection): string
     {
+        if (substr_count($sql, '?') != count($bindings)) {
+            return $sql;
+        }
+
         $sql = str_replace(['%', '?'], ['%%', '%s'], $sql);
 
         $handledBindings = array_map(function ($binding) {

--- a/tests/Collectors/DatabaseQueryCollectorTest.php
+++ b/tests/Collectors/DatabaseQueryCollectorTest.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Napp\Xray\Tests;
+
+use Illuminate\Database\Connection;
+use Napp\Xray\Collectors\DatabaseQueryCollector;
+use Napp\Xray\Segments\Trace;
+use Orchestra\Testbench\TestCase;
+
+class DatabaseQueryCollectorTest extends TestCase
+{
+    public function test_return_query_if_count_not_match()
+    {
+        $connection = $this->createMock(Connection::class);
+
+        $connection->expects($this->once())
+            ->method('getName')
+            ->willReturn('name');
+        $connection->expects($this->once())
+            ->method('getDriverName')
+            ->willReturn('driver-name');
+        $connection->expects($this->never())->method('prepareBindings');
+
+        $collector = new DatabaseQueryCollector($this->app);
+        $collector->current()->begin();
+        $collector->handleQueryReport('abc ? def ? ?', [1, 2], 0, $connection);
+
+        $serialized = $collector->current()->jsonSerialize();
+        $querySerialized = $serialized['subsegments'][0]->jsonSerialize();
+
+        $this->assertEquals('name', $querySerialized['name']);
+        $this->assertEquals('driver-name', $querySerialized['sql']['database_type']);
+        $this->assertEquals('abc ? def ? ?', $querySerialized['sql']['sanitized_query']);
+    }
+
+    public function test_binding_correctly()
+    {
+        $connection = $this->createMock(Connection::class);
+
+        $connection->expects($this->once())
+            ->method('getName')
+            ->willReturn('name');
+        $connection->expects($this->once())
+            ->method('getDriverName')
+            ->willReturn('driver-name');
+        $connection->expects($this->once())
+            ->method('prepareBindings')
+            ->willReturn([123, 'ghi']);
+
+        $collector = new DatabaseQueryCollector($this->app);
+        $collector->current()->begin();
+        $collector->handleQueryReport('abc ? def ?', [1, 2], 0, $connection);
+
+        $serialized = $collector->current()->jsonSerialize();
+        $querySerialized = $serialized['subsegments'][0]->jsonSerialize();
+
+        $this->assertEquals("abc 123 def 'ghi'", $querySerialized['sql']['sanitized_query']);
+    }
+
+    /**
+     * Define environment setup.
+     *
+     * @param  \Illuminate\Foundation\Application  $app
+     * @return void
+     */
+    protected function getEnvironmentSetUp($app)
+    {
+        $app['config']->set('xray.db_bindings', true);
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Trace::flush();
+    }
+}

--- a/tests/Collectors/SegmentCollectorTest.php
+++ b/tests/Collectors/SegmentCollectorTest.php
@@ -6,6 +6,7 @@ namespace Napp\Xray\Tests;
 
 use Illuminate\Http\Request;
 use Napp\Xray\Collectors\SegmentCollector;
+use Napp\Xray\Segments\Trace;
 use Orchestra\Testbench\TestCase;
 use PHPUnit\Framework\MockObject\MockObject;
 
@@ -36,6 +37,7 @@ class SegmentCollectorTest extends TestCase
     public function test_should_add_http_segment()
     {
         $collector = new SegmentCollector();
+        $collector->current()->begin();
         $segment = $collector->addHttpSegment('http://example.com', ['method' => 'POST', 'name' => 'example']);
 
         $data = $collector->getSegment('example')->jsonSerialize();
@@ -62,9 +64,9 @@ class SegmentCollectorTest extends TestCase
         $this->assertTrue(true);
     }
 
-    protected function createRequest(): MockObject
+    protected function createRequest()
     {
-        $request = $this->getMockBuilder(Request::class)->getMock();
+        $request = $this->createMock(Request::class);
 
         $request->expects($this->any())->method('ip')->willReturn('some-ip');
         $request->expects($this->any())->method('url')->willReturn('some-url');
@@ -84,5 +86,12 @@ class SegmentCollectorTest extends TestCase
         $app['config']->set('xray.enabled', true);
         $app['config']->set('xray.sample_rate', 100);
         $app['config']->set('xray.route_filters', ['filter/path']);
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Trace::flush();
     }
 }


### PR DESCRIPTION
VIPOP-11962

有時候 Laravel 並未做變數的抽離，導致 query 有可能會含有特殊符號。